### PR TITLE
Moving additional Oauth values to AppSettings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Secrets.json

--- a/AppSettings.json
+++ b/AppSettings.json
@@ -10,5 +10,11 @@
     "Listener" : {
         "RedirectURL" : "http://localhost:8080/",
         "LandingPage" : "LandingPage.html"
+    },
+    // Store any additional platform specific values to be sent with the request here. Google example shown.
+    "OauthValues" : {
+        "response_type" : "code",
+        "scope" : "profile email",
+        "prompt" : "select_account"
     }
 }

--- a/OAUTH.ps1
+++ b/OAUTH.ps1
@@ -55,10 +55,10 @@ if (($appSettings.Code -Ne "") -And (Test-Path $appSettings.Code)) {
     $query["client_id"] = $client_id
     $query["redirect_uri"] = $appSettings.Listener.RedirectURL
 
-    <# Customize values here for your OAuth of choice, in this case these are Google OAuth values #>
-    $query["response_type"] = "code"
-    $query["scope"] = "profile email"
-    $query["prompt"] = "select_account"
+    <# Customize values here for your OAuth of choice #>
+    foreach ($additionalValue in $appSettings.OauthValues.PSObject.Properties){
+        $query[$additionalValue.Name] = $additionalValue.Value
+    }
 
     $uri.Query = $query.ToString()
 


### PR DESCRIPTION
I figured it may be more convenient to have all of the settings in `AppSettings.json`. With this change you can easily specify any number of arbitrary values to send through the OAuth request.

Thanks for making and sharing this script by the way. Really simplified my day!